### PR TITLE
Arm64/x86 support

### DIFF
--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -6,6 +6,7 @@
 
 !include "WordFunc.nsh"
 !include "TextFunc.nsh"
+!include "X64.nsh"
 
 !ifndef DOTNETCORE_INCLUDED
 !define DOTNETCORE_INCLUDED
@@ -185,13 +186,23 @@
 	Push ${Version}
 	Pop $R0 ; Version
 
+	${If} ${IsNativeAMD64}
+		StrCpy $R3 "x64"
+	${ElseIf} ${IsNativeARM64}
+		StrCpy $R3 "arm64"
+	${ElseIf} ${IsNativeIA32}
+		StrCpy $R3 "x86"
+	${Else}
+		StrCpy $R3 "unknown"
+	${EndIf}
+
 	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/windowsdesktop-runtime-$R0-win-x64.exe
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
 
 	; For dotnet versions less than 5 the WindowsDesktop runtime has a different path
 	${WordFind} $R0 "." "+1" $R2
 	IntCmp $R2 5 +2 0 +2
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/windowsdesktop-runtime-$R0-win-x64.exe
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
 
 	DetailPrint "Downloading dotnet $R0 from $R1"
 

--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -218,7 +218,14 @@
 	!insertmacro DotNetCorePSExec $R1 $R1
 	; $R1 contains powershell script result
 
+	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
+	ifErrors +3 0
+	DetailPrint "Dotnet installer $R0 not found."
+	Goto +5
+
 	; todo error handling for PS result, verify download result
+
+	
 
 	DetailPrint "Download complete"
 

--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -221,11 +221,14 @@
 	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
 	ifErrors +3 0
 	DetailPrint "Dotnet installer $R0 not found."
-	Goto +5
+	Goto +10
 
 	; todo error handling for PS result, verify download result
 
 	
+	IfFileExists $R2 +3, 0
+	DetailPrint "Dotnet installer did not download."
+	Goto +7
 
 	DetailPrint "Download complete"
 


### PR DESCRIPTION
I'm writing a .net core program on an Apple silicon machine. So I have extended your script to check which architecture is running and download the .net core runtime for that architecture. I also added some checks to test whether the installer is available