### PR TITLE
Include net7 in supported dotnet versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 This repository contains macro scripts intended to check whether a particular version of the dotnet
 core runtime is installed and, if not, install it.
 
-Currently only supports installing the appropriate WindowsDesktop runtime for the platform the
-installer is running on (ARM64, X86 or X86).
+Currently only supports installing the `Windows Desktop` runtime. Support for the core runtime only,
+or for `ASP.NET Core` runtime, is not currently implemented.
+
+The platform will be detected during installation and the appropriate runtime installer will be used.
+Supports `ARM64`, `X86` and `X86` platforms.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,8 @@
 This repository contains macro scripts intended to check whether a particular version of the dotnet
 core runtime is installed and, if not, install it.
 
-Very rough'n'ready at the moment with almost noerror handling and currently only supports installing
-the WindowsDesktop runtime. Needs better UI feedback, possibly automatically switching to using
-[Inetc](https://nsis.sourceforge.io/Inetc_plug-in) to perform the download with progress when the
-plugin is available, and would probably benefit from a 'would you like to install... " prompt
-
-Would also be good to handle a three digit version as a "minimum" or "exact" version in future,
-possibly using > as a prefix for "minimum". Right now it just makes sure _any_ version of the
-specified runtime is installed.
+Currently only supports installing the appropriate WindowsDesktop runtime for the platform the
+installer is running on (ARM64, X86 or X86).
 
 # Usage
 
@@ -25,4 +19,5 @@ dotnet is installed
 !insertmacro CheckDotNetCore 3.1
 !insertmacro CheckDotNetCore 5.0
 !insertmacro CheckDotNetCore 6.0
+!insertmacro CheckDotNetCore 7.0
 ```

--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -1,5 +1,5 @@
 ; A set of NSIS macros to check whether a dotnet core runtime is installed and, if not, offer to
-; download and install it. Currently only supports dotnet 6.
+; download and install it. Supports dotnet versions 3.1 and newer - latest tested version is 7.0.
 ;
 ; Inspired by & initially based on NsisDotNetChecker, which does the same thing for .NET framework
 ; https://github.com/alex-sitnikov/NsisDotNetChecker
@@ -14,7 +14,7 @@
 ; Check that a specific version of the dotnet core runtime is installed and, if not, attempts to
 ; install it
 ;
-; \param Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 5.0, 6.0
+; \param Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
 !macro CheckDotNetCore Version
 
 	; Save registers
@@ -74,7 +74,7 @@
 ; Gets the latest version of the runtime for a specified dotnet version. This uses the same endpoint
 ; as the dotnet-install scripts to determine the latest full version of a dotnet version
 ;
-; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 5.0, 6.0
+; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
 ; \param[out] Result The full version number of the latest version - e.g. 6.0.7
 !macro DotNetCoreGetLatestVersion Version Result
 


### PR DESCRIPTION
Added net7 example to the readme.

Also cleaned up 'todo' items from the readme as these are now tracked as issues