### PR TITLE
Full .Net Runtime implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ core runtime is installed and, if not, install it.
 
 All current runtimes (as of early 2025) can be installed checked and installed (dotnet, AspNetCore, WindowsDesktop).
 
-The platform will be detected during installation and the appropriate runtime installer will be used.
+The platform can be defined or detected during installation and the appropriate runtime installer will be used.
 Supports `ARM64`, `X86` and `X86` platforms.
 
 # Usage
@@ -15,32 +15,27 @@ Include the macro header file
 !include "DotNetCore.nsh"
 ```
 
-Include one or more of the following to ensure the dotnet runtime for that version of
-dotnet is installed
+The structure of the macro command is as following:
 ```
-!insertmacro CheckDotNetCore 3.1
-!insertmacro CheckDotNetCore 5.0
-!insertmacro CheckDotNetCore 6.0
-!insertmacro CheckDotNetCore 7.0
+!insertmacro CheckRuntime <Runtime> <Version> <Platform>
+```
+
+`<Runtime>` must be one of `DotNetCore`, `AspNetCore` or `WindowsDesktop` to specify the desired runtime
+to check and (if necessary) to install. `<Version>` defines the major dotnet release version in a 2 digit
+form (e.g. `3.1`, `6.0` or `7.0`). `<Platform>` is an optional parameter to define the target platform.
+Allowed inputs are `x86`, `x64`, `arm64` and `""` (empty). If this input is empty, the installer will
+determine the target platform based on the system.
+
+Complete commands look like the following:
+```
+!insertmacro CheckRuntime "DotNetCore" 3.1 ""
+!insertmacro CheckRuntime "AspNetCore" 3.1 "x64"
+!insertmacro CheckRuntime "AspNetCore" 3.1 ""
+!insertmacro CheckRuntime "WindowsDesktop" 3.1 ""
+!insertmacro CheckRuntime "WindowsDesktop" 3.1 ""
 ...
 ```
 
-Include one or more of the following to ensure the AspNetCore runtime for that version of
-dotnet is installed
-```
-!insertmacro CheckAspNetCore 3.1
-!insertmacro CheckAspNetCore 5.0
-!insertmacro CheckAspNetCore 6.0
-!insertmacro CheckAspNetCore 7.0
-...
-```
-
-Include one or more of the following to ensure the WindowsDesktop runtime for that version of
-dotnet is installed
-```
-!insertmacro CheckWindowsDesktop 3.1
-!insertmacro CheckWindowsDesktop 5.0
-!insertmacro CheckWindowsDesktop 6.0
-!insertmacro CheckWindowsDesktop 7.0
-...
-```
+For backwards compatibility reasons, the old macros are still available and map to the new macros. However,
+they should not be used in new code because the naming is wrong ("DotNetCore" macro maps on WindowsDesktop
+functionality, which was the case in the original implementation)!!!

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ The structure of the macro command is as following:
 !insertmacro CheckRuntime <Runtime> <Version> <Platform>
 ```
 
-`<Runtime>` must be one of `DotNetCore`, `AspNetCore` or `WindowsDesktop` to specify the desired runtime
+`<Runtime>` must be one of `"DotNetCore"`, `"AspNetCore"` or `"WindowsDesktop"` to specify the desired runtime
 to check and (if necessary) to install. `<Version>` defines the major dotnet release version in a 2 digit
 form (e.g. `3.1`, `6.0` or `7.0`). `<Platform>` is an optional parameter to define the target platform.
-Allowed inputs are `x86`, `x64`, `arm64` and `""` (empty). If this input is empty, the installer will
+Allowed inputs are `"x86"`, `"x64"`, `"arm64"` and `""` (empty). If this input is empty, the installer will
 determine the target platform based on the system.
 
 Complete commands look like the following:

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ determine the target platform based on the system.
 Complete commands look like the following:
 ```
 !insertmacro CheckRuntime "DotNetCore" 3.1 ""
-!insertmacro CheckRuntime "AspNetCore" 3.1 "x64"
 !insertmacro CheckRuntime "AspNetCore" 3.1 ""
+!insertmacro CheckRuntime "AspNetCore" 3.1 "x64"
 !insertmacro CheckRuntime "WindowsDesktop" 3.1 ""
-!insertmacro CheckRuntime "WindowsDesktop" 3.1 ""
+!insertmacro CheckRuntime "WindowsDesktop" 3.1 "x86"
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains macro scripts intended to check whether a particular version of the dotnet
 core runtime is installed and, if not, install it.
 
-Currently only supports installing the `Windows Desktop` runtime and `ASP.NET Core` runtime. Support for the core runtime only is not currently implemented.
+All current runtimes (as of early 2025) can be installed checked and installed (dotnet, AspNetCore, WindowsDesktop).
 
 The platform will be detected during installation and the appropriate runtime installer will be used.
 Supports `ARM64`, `X86` and `X86` platforms.
@@ -15,13 +15,14 @@ Include the macro header file
 !include "DotNetCore.nsh"
 ```
 
-Include one or more of the following to ensure the WindowsDesktop runtime for that version of
+Include one or more of the following to ensure the dotnet runtime for that version of
 dotnet is installed
 ```
 !insertmacro CheckDotNetCore 3.1
 !insertmacro CheckDotNetCore 5.0
 !insertmacro CheckDotNetCore 6.0
 !insertmacro CheckDotNetCore 7.0
+...
 ```
 
 Include one or more of the following to ensure the AspNetCore runtime for that version of
@@ -31,4 +32,15 @@ dotnet is installed
 !insertmacro CheckAspNetCore 5.0
 !insertmacro CheckAspNetCore 6.0
 !insertmacro CheckAspNetCore 7.0
+...
+```
+
+Include one or more of the following to ensure the WindowsDesktop runtime for that version of
+dotnet is installed
+```
+!insertmacro CheckWindowsDesktop 3.1
+!insertmacro CheckWindowsDesktop 5.0
+!insertmacro CheckWindowsDesktop 6.0
+!insertmacro CheckWindowsDesktop 7.0
+...
 ```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 This repository contains macro scripts intended to check whether a particular version of the dotnet
 core runtime is installed and, if not, install it.
 
-Currently only supports installing the `Windows Desktop` runtime. Support for the core runtime only,
-or for `ASP.NET Core` runtime, is not currently implemented.
+Currently only supports installing the `Windows Desktop` runtime and `ASP.NET Core` runtime. Support for the core runtime only is not currently implemented.
 
 The platform will be detected during installation and the appropriate runtime installer will be used.
 Supports `ARM64`, `X86` and `X86` platforms.
@@ -23,4 +22,13 @@ dotnet is installed
 !insertmacro CheckDotNetCore 5.0
 !insertmacro CheckDotNetCore 6.0
 !insertmacro CheckDotNetCore 7.0
+```
+
+Include one or more of the following to ensure the AspNetCore runtime for that version of
+dotnet is installed
+```
+!insertmacro CheckAspNetCore 3.1
+!insertmacro CheckAspNetCore 5.0
+!insertmacro CheckAspNetCore 6.0
+!insertmacro CheckAspNetCore 7.0
 ```

--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -69,6 +69,10 @@
 
 !macroend
 
+; Check that a specific version of the asp.net core runtime is installed and, if not, attempts to
+; install it
+;
+; \param Version The desired asp.net core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
 !macro CheckAspNetCore Version
 
 	; Save registers
@@ -123,7 +127,63 @@
 
 !macroend
 
+; Check that a specific version of the windows desktop app runtime (for WinForms and WPF) is installed and,
+; if not, attempts to install it
+;
+; \param Version The desired windows desktop app runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+!macro CheckWindowsDesktop Version
 
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Version}
+	Pop $R0 ; Version
+
+	!define ID ${__LINE__}
+
+	; Check current installed version
+	!insertmacro WindowsDesktopGetInstalledVersion $R0 $R1
+
+	; If $R1 is blank then there is no version installed, otherwise it is installed
+	; todo in future we might want to support "must be at least 6.0.7", for now we only deal with "yes/no" for a major version (e.g. 6.0)
+	StrCmp $R1 "" notinstalled_${ID}
+	DetailPrint "WindowsDesktop version $R1 already installed"
+	Goto end_${ID}
+
+	notinstalled_${ID}:
+	DetailPrint "WindowsDesktop $R0 is not installed"
+
+	!insertmacro WindowsDesktopGetLatestVersion $R0 $R1
+	DetailPrint "Latest Version of $R0 is $R1"
+
+
+	; Get number of input digits
+	; ${WordFind} $R1 "." "#" $R2
+	; DetailPrint "version parts count is $R2"
+
+	; ${WordFind} $R1 "." "+1" $R2
+	; DetailPrint "version part 1 is $R2"
+
+	; ${WordFind} $R1 "." "+2" $R2
+	; DetailPrint "version part 2 is $R2"
+
+	; ${WordFind} $R1 "." "+3" $R2
+	; DetailPrint "version part 3 is $R2"
+
+	!insertmacro WindowsDesktopInstallVersion $R1
+
+	end_${ID}:
+	!undef ID
+
+	; Restore registers
+	Pop $R2
+	Pop $R1
+	Pop $R0
+
+!macroend
 
 ; Gets the latest version of the runtime for a specified dotnet version. This uses the same endpoint
 ; as the dotnet-install scripts to determine the latest full version of a dotnet version
@@ -141,13 +201,13 @@
 	Push ${Version}
 	Pop $R0 ; Version
 
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/latest.version
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/latest.version
 	DetailPrint "Querying latest version of dotnet $R0 from $R1"
 
 	; Fetch latest version of the desired dotnet version
 	; todo error handling in the PS script? so we can check for errors here
 	StrCpy $R2 "Write-Host (Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\").Content;"
-	!insertmacro DotNetCorePSExec $R2 $R2
+	!insertmacro ExecPSScript $R2 $R2
 	; $R2 contains latest version, e.g. 6.0.7
 
 	; todo error handling here
@@ -169,7 +229,7 @@
 
 !macroend
 
-; Gets the latest version of the runtime for a specified dotnet version. This uses the same endpoint
+; Gets the latest version of the asp.net runtime for a specified dotnet version. This uses the same endpoint
 ; as the dotnet-install scripts to determine the latest full version of a dotnet version
 ;
 ; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
@@ -191,7 +251,7 @@
 	; Fetch latest version of the desired dotnet version
 	; todo error handling in the PS script? so we can check for errors here
 	StrCpy $R2 "Write-Host (Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\").Content;"
-	!insertmacro DotNetCorePSExec $R2 $R2
+	!insertmacro ExecPSScript $R2 $R2
 	; $R2 contains latest version, e.g. 6.0.7
 
 	; todo error handling here
@@ -213,7 +273,49 @@
 
 !macroend
 
+; Gets the latest version of the windows desktop runtime for a specified dotnet version. This uses the same endpoint
+; as the dotnet-install scripts to determine the latest full version of a dotnet version
+;
+; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+; \param[out] Result The full version number of the latest version - e.g. 6.0.7
+!macro WindowsDesktopGetLatestVersion Version Result
 
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Version}
+	Pop $R0 ; Version
+
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/latest.version
+	DetailPrint "Querying latest version of dotnet $R0 from $R1"
+
+	; Fetch latest version of the desired dotnet version
+	; todo error handling in the PS script? so we can check for errors here
+	StrCpy $R2 "Write-Host (Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\").Content;"
+	!insertmacro ExecPSScript $R2 $R2
+	; $R2 contains latest version, e.g. 6.0.7
+
+	; todo error handling here
+
+	; Push the result onto the stack
+	${TrimNewLines} $R2 $R2
+	Push $R2
+
+	; Restore registers
+	Exch
+	Pop $R2
+	Exch
+	Pop $R1
+	Exch
+	Pop $R0
+
+	; Set result
+	Pop ${Result}
+
+!macroend
 
 !macro DotNetCoreGetInstalledVersion Version Result
 	!define DNC_INS_ID ${__LINE__}
@@ -229,8 +331,8 @@
 
 	DetailPrint "Checking installed version of dotnet $R0"
 
-	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*WindowsDesktop.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
-	!insertmacro DotNetCorePSExec $R1 $R1
+	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*NETCore.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
+	!insertmacro ExecPSScript $R1 $R1
 	; $R1 contains highest installed version, e.g. 6.0.7
 
 	${TrimNewLines} $R1 $R1
@@ -289,7 +391,66 @@
 	DetailPrint "Checking installed version of AspNetCore $R0"
 
 	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*AspNet.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
-	!insertmacro DotNetCorePSExec $R1 $R1
+	!insertmacro ExecPSScript $R1 $R1
+	; $R1 contains highest installed version, e.g. 6.0.7
+
+	${TrimNewLines} $R1 $R1
+
+	; If there is an installed version it should start with the same two "words" as the input version,
+	; otherwise assume we got an error response
+
+	; todo improve this simple test which checks there are at least 3 "words" separated by periods
+	${WordFind} $R1 "." "E#" $R2
+	IfErrors error_${DNC_INS_ID}
+	; $R2 contains number of version parts in R1 (dot separated words = version parts)
+
+	; If less than 3 parts, or more than 4 parts, error
+	IntCmp $R2 3 0 error_${DNC_INS_ID}
+	IntCmp $R2 4 0 0 error_${DNC_INS_ID}
+
+	; todo more error handling here / validation
+
+	; Seems to be OK, skip the "set to blank string" error handler
+	Goto end_${DNC_INS_ID}
+
+	error_${DNC_INS_ID}:
+	StrCpy $R1 "" ; Set result to blank string if any error occurs (means not installed)
+
+	end_${DNC_INS_ID}:
+	!undef DNC_INS_ID
+
+	; Push the result onto the stack
+	Push $R1
+
+	; Restore registers
+	Exch
+	Pop $R2
+	Exch
+	Pop $R1
+	Exch
+	Pop $R0
+
+	; Set result
+	Pop ${Result}
+
+!macroend
+
+!macro WindowsDesktopGetInstalledVersion Version Result
+	!define DNC_INS_ID ${__LINE__}
+
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Version}
+	Pop $R0 ; Version
+
+	DetailPrint "Checking installed version of dotnet $R0"
+
+	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*WindowsDesktop.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
+	!insertmacro ExecPSScript $R1 $R1
 	; $R1 contains highest installed version, e.g. 6.0.7
 
 	${TrimNewLines} $R1 $R1
@@ -356,12 +517,7 @@
 	${EndIf}
 
 	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
-
-	; For dotnet versions less than 5 the WindowsDesktop runtime has a different path
-	${WordFind} $R0 "." "+1" $R2
-	IntCmp $R2 5 +2 0 +2
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/dotnet-runtime-$R0-win-$R3.exe
 
 	DetailPrint "Downloading dotnet $R0 from $R1"
 
@@ -374,7 +530,7 @@
 	; Fetch runtime installer
 	; todo error handling in the PS script? so we can check for errors here
 	StrCpy $R1 "Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\" -OutFile $\"$R2$\""
-	!insertmacro DotNetCorePSExec $R1 $R1
+	!insertmacro ExecPSScript $R1 $R1
 	; $R1 contains powershell script result
 
 	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
@@ -433,11 +589,6 @@
 	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
 	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R0/dotnet-hosting-$R0-win.exe
 
-	; For dotnet versions less than 5 the WindowsDesktop runtime has a different path
-	${WordFind} $R0 "." "+1" $R2
-	IntCmp $R2 5 +2 0 +2
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R0/dotnet-hosting-$R0-win.exe
-
 	DetailPrint "Downloading dotnet $R0 from $R1"
 
 	; Create destination file
@@ -449,7 +600,7 @@
 	; Fetch runtime installer
 	; todo error handling in the PS script? so we can check for errors here
 	StrCpy $R1 "Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\" -OutFile $\"$R2$\""
-	!insertmacro DotNetCorePSExec $R1 $R1
+	!insertmacro ExecPSScript $R1 $R1
 	; $R1 contains powershell script result
 
 	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
@@ -483,37 +634,112 @@
 
 !macroend
 
+!macro WindowsDesktopInstallVersion Version
+
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+	Push $R3
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Version}
+	Pop $R0 ; Version
+
+	${If} ${IsNativeAMD64}
+		StrCpy $R3 "x64"
+	${ElseIf} ${IsNativeARM64}
+		StrCpy $R3 "arm64"
+	${ElseIf} ${IsNativeIA32}
+		StrCpy $R3 "x86"
+	${Else}
+		StrCpy $R3 "unknown"
+	${EndIf}
+
+	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
+
+	; For dotnet versions less than 5 the WindowsDesktop runtime has a different path
+	${WordFind} $R0 "." "+1" $R2
+	IntCmp $R2 5 +2 0 +2
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
+
+	DetailPrint "Downloading dotnet $R0 from $R1"
+
+	; Create destination file
+	GetTempFileName $R2
+	nsExec::Exec 'cmd.exe /c rename "$R2" "$R2.exe"'	; Not using Rename to avoid spam in details log
+	Pop $R3 ; Pop exit code
+	StrCpy $R2 "$R2.exe"
+	
+	; Fetch runtime installer
+	; todo error handling in the PS script? so we can check for errors here
+	StrCpy $R1 "Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\" -OutFile $\"$R2$\""
+	!insertmacro ExecPSScript $R1 $R1
+	; $R1 contains powershell script result
+
+	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
+	ifErrors +3 0
+	DetailPrint "Dotnet installer $R0 not found."
+	Goto +10
+
+	; todo error handling for PS result, verify download result
+
+	
+	IfFileExists $R2 +3, 0
+	DetailPrint "Dotnet installer did not download."
+	Goto +7
+
+	DetailPrint "Download complete"
+
+	DetailPrint "Installing dotnet $R0"
+	ExecWait "$\"$R2$\" /install /quiet /norestart" $R1
+	DetailPrint "Installer completed (Result: $R1)"
+
+	nsExec::Exec 'cmd.exe /c del "$R2"'	; Not using Delete to avoid spam in details log
+	Pop $R3 ; Pop exit code
+
+	; Error checking? Verify install result?
+
+	; Restore registers
+	Pop $R3
+	Pop $R2
+	Pop $R1
+	Pop $R0
+
+!macroend
+
 ; below is adapted from https://nsis.sourceforge.io/PowerShell_support but avoids using the plugin
 ; directory in favour of a temp file and providing a return variable rather than returning on the
 ; stack. Methods renamed to avoid conflicting with use of the original macros
 
-; DotNetCorePSExec
+; ExecPSScript
 ; Executes a powershell script
 ;
 ; \param[in] PSCommand The powershell command or script to execute
 ; \param[out] Result The output from the powershell script
-!macro DotNetCorePSExec PSCommand Result
+!macro ExecPSScript PSCommand Result
 
 	Push ${PSCommand}
-	Call DotNetCorePSExecFn
+	Call ExecPSScriptFn
 	Pop ${Result}
 
 !macroend
 
-; DotNetCorePSExecFile
+; ExecPSScriptFile
 ; Executes a powershell file
 ;
 ; \param[in] FilePath The path to the powershell script file to execute
 ; \param[out] Result The output from the powershell script
-!macro DotNetCorePSExecFile FilePath Result
+!macro ExecPSScriptFile FilePath Result
 
 	Push ${FilePath}
-	Call DotNetCorePSExecFileFn
+	Call ExecPSScriptFileFn
 	Pop ${Result}
 
 !macroend
 
-Function DotNetCorePSExecFn
+Function ExecPSScriptFn
 
 	; Read parameters and save registers
 	Exch $R0	; Script
@@ -534,7 +760,7 @@ Function DotNetCorePSExecFn
 
 	; Execute the powershell script and delete the temp file
 	Push $R1
-	Call DotNetCorePSExecFileFn
+	Call ExecPSScriptFileFn
 	nsExec::Exec 'cmd.exe /c del "$R1"'	; Not using Delete to avoid spam in details log
 	Pop $R0 ; Pop exit code
 
@@ -550,7 +776,7 @@ Function DotNetCorePSExecFn
 
 FunctionEnd
 
-Function DotNetCorePSExecFileFn
+Function ExecPSScriptFileFn
 
 	; Read parameters and save registers
 	Exch $R0	; FilePath

--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -290,7 +290,7 @@
 	Pop $R0 ; Version
 
 	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/latest.version
-	DetailPrint "Querying latest version of dotnet $R0 from $R1"
+	DetailPrint "Querying latest version of WindowsDesktop runtime $R0 from $R1"
 
 	; Fetch latest version of the desired dotnet version
 	; todo error handling in the PS script? so we can check for errors here
@@ -447,7 +447,7 @@
 	Push ${Version}
 	Pop $R0 ; Version
 
-	DetailPrint "Checking installed version of dotnet $R0"
+	DetailPrint "Checking installed version of WindowsDesktop runtime $R0"
 
 	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*WindowsDesktop.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
 	!insertmacro ExecPSScript $R1 $R1
@@ -589,7 +589,7 @@
 	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
 	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R0/dotnet-hosting-$R0-win.exe
 
-	DetailPrint "Downloading dotnet $R0 from $R1"
+	DetailPrint "Downloading AspNetCore $R0 from $R1"
 
 	; Create destination file
 	GetTempFileName $R2
@@ -664,7 +664,7 @@
 	IntCmp $R2 5 +2 0 +2
 	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
 
-	DetailPrint "Downloading dotnet $R0 from $R1"
+	DetailPrint "Downloading WindowsDesktop runtime $R0 from $R1"
 
 	; Create destination file
 	GetTempFileName $R2
@@ -680,19 +680,19 @@
 
 	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
 	ifErrors +3 0
-	DetailPrint "Dotnet installer $R0 not found."
+	DetailPrint "WindowsDesktop runtime installer $R0 not found."
 	Goto +10
 
 	; todo error handling for PS result, verify download result
 
 	
 	IfFileExists $R2 +3, 0
-	DetailPrint "Dotnet installer did not download."
+	DetailPrint "WindowsDesktop runtime installer did not download."
 	Goto +7
 
 	DetailPrint "Download complete"
 
-	DetailPrint "Installing dotnet $R0"
+	DetailPrint "Installing WindowsDesktop runtime $R0"
 	ExecWait "$\"$R2$\" /install /quiet /norestart" $R1
 	DetailPrint "Installer completed (Result: $R1)"
 

--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -43,20 +43,6 @@
 	!insertmacro DotNetCoreGetLatestVersion $R0 $R1
 	DetailPrint "Latest Version of $R0 is $R1"
 
-
-	; Get number of input digits
-	; ${WordFind} $R1 "." "#" $R2
-	; DetailPrint "version parts count is $R2"
-
-	; ${WordFind} $R1 "." "+1" $R2
-	; DetailPrint "version part 1 is $R2"
-
-	; ${WordFind} $R1 "." "+2" $R2
-	; DetailPrint "version part 2 is $R2"
-
-	; ${WordFind} $R1 "." "+3" $R2
-	; DetailPrint "version part 3 is $R2"
-
 	!insertmacro DotNetCoreInstallVersion $R1
 
 	end_${ID}:
@@ -101,20 +87,6 @@
 	!insertmacro AspNetCoreGetLatestVersion $R0 $R1
 	DetailPrint "Latest Version of $R0 is $R1"
 
-
-	; Get number of input digits
-	; ${WordFind} $R1 "." "#" $R2
-	; DetailPrint "version parts count is $R2"
-
-	; ${WordFind} $R1 "." "+1" $R2
-	; DetailPrint "version part 1 is $R2"
-
-	; ${WordFind} $R1 "." "+2" $R2
-	; DetailPrint "version part 2 is $R2"
-
-	; ${WordFind} $R1 "." "+3" $R2
-	; DetailPrint "version part 3 is $R2"
-
 	!insertmacro AspNetCoreInstallVersion $R1
 
 	end_${ID}:
@@ -158,20 +130,6 @@
 
 	!insertmacro WindowsDesktopGetLatestVersion $R0 $R1
 	DetailPrint "Latest Version of $R0 is $R1"
-
-
-	; Get number of input digits
-	; ${WordFind} $R1 "." "#" $R2
-	; DetailPrint "version parts count is $R2"
-
-	; ${WordFind} $R1 "." "+1" $R2
-	; DetailPrint "version part 1 is $R2"
-
-	; ${WordFind} $R1 "." "+2" $R2
-	; DetailPrint "version part 2 is $R2"
-
-	; ${WordFind} $R1 "." "+3" $R2
-	; DetailPrint "version part 3 is $R2"
 
 	!insertmacro WindowsDesktopInstallVersion $R1
 

--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -11,132 +11,67 @@
 !ifndef DOTNETCORE_INCLUDED
 !define DOTNETCORE_INCLUDED
 
-; Check that a specific version of the dotnet core runtime is installed and, if not, attempts to
+;------------------------------------------------------------------------------------------------------
+; Main Macro Section
+;------------------------------------------------------------------------------------------------------
+
+; Check that a specific version of a specified runtime is installed and, if not, attempts to
 ; install it
 ;
+; \param Runtime Define the desired runtime. Allowed are 'DotNetCore', 'AspNetCore' and 'WindowsDesktop'
 ; \param Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
-!macro CheckDotNetCore Version
+!macro CheckRuntime Runtime Version Platform
 
 	; Save registers
 	Push $R0
 	Push $R1
 	Push $R2
+	Push $R3
 
 	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Runtime}
+	Pop $R0 ; Runtime
 	Push ${Version}
-	Pop $R0 ; Version
+	Pop $R1 ; Version
+	Push `${Platform}`
+	Pop $R2 ; Platform
+
+	${Switch} $R0
+		${Case} 'DotNetCore'
+		${Case} 'AspNetCore'
+		${Case} 'WindowsDesktop'
+			DetailPrint 'Run check for runtime of $R0'
+			${Break}
+		${Default}
+			DetailPrint "Runtime is not defined correctly in CheckRuntime. 'DotNetCore', 'AspNetCore' or 'WindowsDesktop' expected. Found: $0"
+			Abort
+			${Break}
+	${EndSwitch}
 
 	!define ID ${__LINE__}
 
 	; Check current installed version
-	!insertmacro DotNetCoreGetInstalledVersion $R0 $R1
+	!insertmacro RuntimeGetInstalledVersion $R0 $R1 $R3
 
-	; If $R1 is blank then there is no version installed, otherwise it is installed
+	; If $R3 is blank then there is no version installed, otherwise it is installed
 	; todo in future we might want to support "must be at least 6.0.7", for now we only deal with "yes/no" for a major version (e.g. 6.0)
-	StrCmp $R1 "" notinstalled_${ID}
-	DetailPrint "dotnet version $R1 already installed"
+	StrCmp $R3 "" notinstalled_${ID}
+	DetailPrint "$R0 version $R3 already installed"
 	Goto end_${ID}
 
 	notinstalled_${ID}:
-	DetailPrint "dotnet $R0 is not installed"
+	DetailPrint "$R0 $R1 is not installed"
 
-	!insertmacro DotNetCoreGetLatestVersion $R0 $R1
-	DetailPrint "Latest Version of $R0 is $R1"
+	!insertmacro RuntimeGetLatestVersion $R0 $R1 $R3
+	DetailPrint "Latest Version of $R0 $R1 is $R3"
 
-	!insertmacro DotNetCoreInstallVersion $R1
+	!insertmacro RuntimeInstallVersion $R0 $R3 $R2
 
 	end_${ID}:
 	!undef ID
 
 	; Restore registers
-	Pop $R2
-	Pop $R1
-	Pop $R0
-
-!macroend
-
-; Check that a specific version of the asp.net core runtime is installed and, if not, attempts to
-; install it
-;
-; \param Version The desired asp.net core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
-!macro CheckAspNetCore Version
-
-	; Save registers
-	Push $R0
-	Push $R1
-	Push $R2
-
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	!define ID ${__LINE__}
-
-	; Check current installed version
-	!insertmacro AspNetCoreGetInstalledVersion $R0 $R1
-
-	; If $R1 is blank then there is no version installed, otherwise it is installed
-	; todo in future we might want to support "must be at least 6.0.7", for now we only deal with "yes/no" for a major version (e.g. 6.0)
-	StrCmp $R1 "" notinstalled_${ID}
-	DetailPrint "AspNetCore version $R1 already installed"
-	Goto end_${ID}
-
-	notinstalled_${ID}:
-	DetailPrint "AspNetCore $R0 is not installed"
-
-	!insertmacro AspNetCoreGetLatestVersion $R0 $R1
-	DetailPrint "Latest Version of $R0 is $R1"
-
-	!insertmacro AspNetCoreInstallVersion $R1
-
-	end_${ID}:
-	!undef ID
-
-	; Restore registers
-	Pop $R2
-	Pop $R1
-	Pop $R0
-
-!macroend
-
-; Check that a specific version of the windows desktop app runtime (for WinForms and WPF) is installed and,
-; if not, attempts to install it
-;
-; \param Version The desired windows desktop app runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
-!macro CheckWindowsDesktop Version
-
-	; Save registers
-	Push $R0
-	Push $R1
-	Push $R2
-
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	!define ID ${__LINE__}
-
-	; Check current installed version
-	!insertmacro WindowsDesktopGetInstalledVersion $R0 $R1
-
-	; If $R1 is blank then there is no version installed, otherwise it is installed
-	; todo in future we might want to support "must be at least 6.0.7", for now we only deal with "yes/no" for a major version (e.g. 6.0)
-	StrCmp $R1 "" notinstalled_${ID}
-	DetailPrint "WindowsDesktop version $R1 already installed"
-	Goto end_${ID}
-
-	notinstalled_${ID}:
-	DetailPrint "WindowsDesktop $R0 is not installed"
-
-	!insertmacro WindowsDesktopGetLatestVersion $R0 $R1
-	DetailPrint "Latest Version of $R0 is $R1"
-
-	!insertmacro WindowsDesktopInstallVersion $R1
-
-	end_${ID}:
-	!undef ID
-
-	; Restore registers
+	Pop $R3
 	Pop $R2
 	Pop $R1
 	Pop $R0
@@ -146,35 +81,56 @@
 ; Gets the latest version of the runtime for a specified dotnet version. This uses the same endpoint
 ; as the dotnet-install scripts to determine the latest full version of a dotnet version
 ;
-; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+; \param[in] Runtime Define the desired runtime. Allowed are 'DotNetCore', 'AspNetCore' and 'WindowsDesktop'
+; \param[in] Version The desired runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
 ; \param[out] Result The full version number of the latest version - e.g. 6.0.7
-!macro DotNetCoreGetLatestVersion Version Result
+!macro RuntimeGetLatestVersion Runtime Version Result
 
 	; Save registers
 	Push $R0
 	Push $R1
 	Push $R2
+	Push $R3
 
 	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Runtime}
+	Pop $R0 ; Runtime
 	Push ${Version}
-	Pop $R0 ; Version
+	Pop $R1 ; Version
 
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/latest.version
-	DetailPrint "Querying latest version of dotnet $R0 from $R1"
+	${Switch} $R0
+		${Case} 'DotNetCore'
+			StrCpy $R2 https://dotnetcli.azureedge.net/dotnet/Runtime/$R1/latest.version
+			${Break}
+		${Case} 'AspNetCore'
+			StrCpy $R2 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R1/latest.version
+			${Break}
+		${Case} 'WindowsDesktop'
+			StrCpy $R2 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R1/latest.version
+			${Break}
+		${Default}
+			DetailPrint "Runtime is not defined correctly in RuntimeGetLatestVersion. 'DotNetCore', 'AspNetCore' or 'WindowsDesktop' expected. Found: $0"
+			Abort
+			${Break}
+	${EndSwitch}
+	
+	DetailPrint "Querying latest version of $R0 $R1 from $R2"
 
 	; Fetch latest version of the desired dotnet version
 	; todo error handling in the PS script? so we can check for errors here
-	StrCpy $R2 "Write-Host (Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\").Content;"
-	!insertmacro ExecPSScript $R2 $R2
-	; $R2 contains latest version, e.g. 6.0.7
+	StrCpy $R3 "Write-Host (Invoke-WebRequest -UseBasicParsing -URI $\"$R2$\").Content;"
+	!insertmacro ExecPSScript $R3 $R3
+	; $R3 contains latest version, e.g. 6.0.7
 
 	; todo error handling here
 
 	; Push the result onto the stack
-	${TrimNewLines} $R2 $R2
-	Push $R2
+	${TrimNewLines} $R3 $R3
+	Push $R3
 
 	; Restore registers
+	Exch
+	Pop $R3
 	Exch
 	Pop $R2
 	Exch
@@ -187,487 +143,331 @@
 
 !macroend
 
-; Gets the latest version of the asp.net runtime for a specified dotnet version. This uses the same endpoint
-; as the dotnet-install scripts to determine the latest full version of a dotnet version
+; Gets the currently installed version of the runtime for a specified dotnet version. This uses the dotnet executable
+; as the dotnet-install scripts do to determine the latest installed version
+;
+; \param[in] Runtime Define the desired runtime. Allowed are 'DotNetCore', 'AspNetCore' and 'WindowsDesktop'
+; \param[in] Version The desired runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+; \param[out] Result The full version number of the latest version - e.g. 6.0.7
+!macro RuntimeGetInstalledVersion Runtime Version Result
+	!define DNC_INS_ID ${__LINE__}
+
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+	Push $R3
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Runtime}
+	Pop $R0 ; Runtime
+	Push ${Version}
+	Pop $R1 ; Version
+
+	${Switch} $R0
+		${Case} 'DotNetCore'
+			StrCpy $R2 "dotnet --list-runtimes | % { if($$_ -match $\".*NETCore.*($R1.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
+			${Break}
+		${Case} 'AspNetCore'
+			StrCpy $R2 "dotnet --list-runtimes | % { if($$_ -match $\".*AspNet.*($R1.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
+			${Break}
+		${Case} 'WindowsDesktop'
+			StrCpy $R2 "dotnet --list-runtimes | % { if($$_ -match $\".*WindowsDesktop.*($R1.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
+			${Break}
+		${Default}
+			DetailPrint "Runtime is not defined correctly in RuntimeGetInstalledVersion. 'DotNetCore', 'AspNetCore' or 'WindowsDesktop' expected. Found: $0"
+			Abort
+			${Break}
+	${EndSwitch}
+
+	DetailPrint "Checking installed version of $R0 $R1"
+
+	!insertmacro ExecPSScript $R2 $R2
+	; $R2 contains highest installed version, e.g. 6.0.7
+
+	${TrimNewLines} $R2 $R2
+
+	; If there is an installed version it should start with the same two "words" as the input version,
+	; otherwise assume we got an error response
+
+	; todo improve this simple test which checks there are at least 3 "words" separated by periods
+	${WordFind} $R2 "." "E#" $R3
+	IfErrors error_${DNC_INS_ID}
+	; $R3 contains number of version parts in R2 (dot separated words = version parts)
+
+	; If less than 3 parts, or more than 4 parts, error
+	IntCmp $R3 3 0 error_${DNC_INS_ID}
+	IntCmp $R3 4 0 0 error_${DNC_INS_ID}
+
+	; todo more error handling here / validation
+
+	; Seems to be OK, skip the "set to blank string" error handler
+	Goto end_${DNC_INS_ID}
+
+	error_${DNC_INS_ID}:
+	StrCpy $R2 "" ; Set result to blank string if any error occurs (means not installed)
+
+	end_${DNC_INS_ID}:
+	!undef DNC_INS_ID
+
+	; Push the result onto the stack
+	Push $R2
+
+	; Restore registers
+	Exch
+	Pop $R3
+	Exch
+	Pop $R2
+	Exch
+	Pop $R1
+	Exch
+	Pop $R0
+
+	; Set result
+	Pop ${Result}
+
+!macroend
+
+; Downloads a specific version of a runtime.
+;
+; \param Runtime Define the desired runtime. Allowed are 'DotNetCore', 'AspNetCore' and 'WindowsDesktop'
+; \param Version The desired full version as a 3 digit version. e.g. 3.1.32, 6.0.12, 7.0.0
+; \param Platform Specifies the desired platform of the installer. Allowed are 'x86', 'x64' and 'arm64'. If this parameter is "", the platform is determined by the installer
+!macro RuntimeInstallVersion Runtime Version Platform
+
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+	Push $R3
+	Push $R4
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Runtime}
+	Pop $R0 ; Runtime
+	Push ${Version}
+	Pop $R1 ; Version
+	Push `${Platform}`
+	Pop $R4 ; Platform
+
+	${Switch} $R4
+		${Case} 'x86'
+		${Case} 'x64'
+		${Case} 'arm64'
+			DetailPrint "Specified platform is $R4"
+			${Break}
+		${Default}
+			DetailPrint "Platform not specified. Check current platform"
+			${If} ${IsNativeAMD64}
+				StrCpy $R4 "x64"
+			${ElseIf} ${IsNativeARM64}
+				StrCpy $R4 "arm64"
+			${ElseIf} ${IsNativeIA32}
+				StrCpy $R4 "x86"
+			${Else}
+				StrCpy $R4 "unknown"
+			${EndIf}
+			${Break}
+	${EndSwitch}
+
+	${Switch} $R0
+		${Case} 'DotNetCore'
+			; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
+			StrCpy $R2 https://dotnetcli.azureedge.net/dotnet/Runtime/$R1/dotnet-runtime-$R1-win-$R4.exe
+			${Break}
+		${Case} 'AspNetCore'
+			; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
+			StrCpy $R2 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R1/dotnet-hosting-$R1-win.exe
+			${Break}
+		${Case} 'WindowsDesktop'
+			; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
+			StrCpy $R2 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R1/windowsdesktop-runtime-$R1-win-$R4.exe
+
+			; For dotnet versions less than 5 the WindowsDesktop runtime has a different path
+			${WordFind} $R1 "." "+1" $R3
+			IntCmp $R3 5 +2 0 +2
+			StrCpy $R2 https://dotnetcli.azureedge.net/dotnet/Runtime/$R1/windowsdesktop-runtime-$R1-win-$R4.exe
+			${Break}
+		${Default}
+			DetailPrint "Runtime is not defined correctly in RuntimeInstallVersion. 'DotNetCore', 'AspNetCore' or 'WindowsDesktop' expected. Found: $0"
+			Abort
+			${Break}
+	${EndSwitch}
+
+	DetailPrint "Downloading $R0 runtime $R1 for $R4 from $R2"
+
+	; Create destination file
+	GetTempFileName $R3
+	nsExec::Exec 'cmd.exe /c rename "$R3" "$R3.exe"'	; Not using Rename to avoid spam in details log
+	Pop $R4 ; Pop exit code
+	StrCpy $R3 "$R3.exe"
+	
+	; Fetch runtime installer
+	; todo error handling in the PS script? so we can check for errors here
+	StrCpy $R2 "Invoke-WebRequest -UseBasicParsing -URI $\"$R2$\" -OutFile $\"$R3$\""
+	!insertmacro ExecPSScript $R2 $R2
+	; $R2 contains powershell script result
+
+	${WordFind} $R2 "BlobNotFound " "E+1{" $R4
+	ifErrors +3 0
+	DetailPrint "$R0 runtime installer $R1 not found."
+	Goto +10
+
+	; todo error handling for PS result, verify download result
+
+	IfFileExists $R3 +3, 0
+	DetailPrint "$R0 runtime installer did not download."
+	Goto +7
+
+	DetailPrint "Download complete"
+
+	DetailPrint "Installing $R0 runtime $R1"
+	ExecWait "$\"$R3$\" /install /quiet /norestart" $R2
+	DetailPrint "Installer completed (Result: $R2)"
+
+	nsExec::Exec 'cmd.exe /c del "$R3"'	; Not using Delete to avoid spam in details log
+	Pop $R4 ; Pop exit code
+
+	; Error checking? Verify install result?
+
+	; Restore registers
+	Pop $R4
+	Pop $R3
+	Pop $R2
+	Pop $R1
+	Pop $R0
+
+!macroend
+
+;------------------------------------------------------------------------------------------------
+; Backwards compatibility Section
+;------------------------------------------------------------------------------------------------
+
+; DEPRICATED
+; Backwards compatible macro for the WindowsDesktop runtime
+;
+; \param Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+!macro CheckDotNetCore Version
+	!insertmacro CheckRuntime "WindowsDesktop" ${Version} ""
+!macroend
+
+; DEPRICATED
+; Backwards compatible macro for the AspNetCore runtime
+;
+; \param Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+!macro CheckAspNetCore Version
+	!insertmacro CheckRuntime "AspNetCore" ${Version} ""
+!macroend
+
+; DEPRICATED
+; Backwards compatible macro to get latest WindowsDesktop runtime version
+;
+; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+; \param[out] Result The full version number of the latest version - e.g. 6.0.7
+!macro DotNetCoreGetLatestVersion Version Result
+	; Save registers
+	Push $R0
+
+	!insertmacro RuntimeGetLatestVersion "WindowsDesktop" ${Version} $R0
+
+	; Push the result onto the stack
+	Push $R0
+
+	; Restore registers
+	Exch
+	Pop $R0
+
+	; Set result
+	Pop ${Result}
+!macroend
+
+; DEPRICATED
+; Backwards compatible macro to get latest AspNetCore runtime version
 ;
 ; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
 ; \param[out] Result The full version number of the latest version - e.g. 6.0.7
 !macro AspNetCoreGetLatestVersion Version Result
-
 	; Save registers
 	Push $R0
-	Push $R1
-	Push $R2
 
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R0/latest.version
-	DetailPrint "Querying latest version of AspNetCore $R0 from $R1"
-
-	; Fetch latest version of the desired dotnet version
-	; todo error handling in the PS script? so we can check for errors here
-	StrCpy $R2 "Write-Host (Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\").Content;"
-	!insertmacro ExecPSScript $R2 $R2
-	; $R2 contains latest version, e.g. 6.0.7
-
-	; todo error handling here
+	!insertmacro RuntimeGetLatestVersion 'AspNetCore' ${Version} $R0
 
 	; Push the result onto the stack
-	${TrimNewLines} $R2 $R2
-	Push $R2
+	Push $R0
 
 	; Restore registers
-	Exch
-	Pop $R2
-	Exch
-	Pop $R1
 	Exch
 	Pop $R0
 
 	; Set result
 	Pop ${Result}
-
 !macroend
 
-; Gets the latest version of the windows desktop runtime for a specified dotnet version. This uses the same endpoint
-; as the dotnet-install scripts to determine the latest full version of a dotnet version
+; DEPRICATED
+; Backwards compatible macro to get the currently installed WindowsDesktop runtime version
 ;
 ; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
 ; \param[out] Result The full version number of the latest version - e.g. 6.0.7
-!macro WindowsDesktopGetLatestVersion Version Result
-
-	; Save registers
-	Push $R0
-	Push $R1
-	Push $R2
-
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/latest.version
-	DetailPrint "Querying latest version of WindowsDesktop runtime $R0 from $R1"
-
-	; Fetch latest version of the desired dotnet version
-	; todo error handling in the PS script? so we can check for errors here
-	StrCpy $R2 "Write-Host (Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\").Content;"
-	!insertmacro ExecPSScript $R2 $R2
-	; $R2 contains latest version, e.g. 6.0.7
-
-	; todo error handling here
-
-	; Push the result onto the stack
-	${TrimNewLines} $R2 $R2
-	Push $R2
-
-	; Restore registers
-	Exch
-	Pop $R2
-	Exch
-	Pop $R1
-	Exch
-	Pop $R0
-
-	; Set result
-	Pop ${Result}
-
-!macroend
-
 !macro DotNetCoreGetInstalledVersion Version Result
-	!define DNC_INS_ID ${__LINE__}
-
 	; Save registers
 	Push $R0
-	Push $R1
-	Push $R2
 
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	DetailPrint "Checking installed version of dotnet $R0"
-
-	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*NETCore.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
-	!insertmacro ExecPSScript $R1 $R1
-	; $R1 contains highest installed version, e.g. 6.0.7
-
-	${TrimNewLines} $R1 $R1
-
-	; If there is an installed version it should start with the same two "words" as the input version,
-	; otherwise assume we got an error response
-
-	; todo improve this simple test which checks there are at least 3 "words" separated by periods
-	${WordFind} $R1 "." "E#" $R2
-	IfErrors error_${DNC_INS_ID}
-	; $R2 contains number of version parts in R1 (dot separated words = version parts)
-
-	; If less than 3 parts, or more than 4 parts, error
-	IntCmp $R2 3 0 error_${DNC_INS_ID}
-	IntCmp $R2 4 0 0 error_${DNC_INS_ID}
-
-	; todo more error handling here / validation
-
-	; Seems to be OK, skip the "set to blank string" error handler
-	Goto end_${DNC_INS_ID}
-
-	error_${DNC_INS_ID}:
-	StrCpy $R1 "" ; Set result to blank string if any error occurs (means not installed)
-
-	end_${DNC_INS_ID}:
-	!undef DNC_INS_ID
+	!insertmacro RuntimeGetInstalledVersion "WindowsDesktop" ${Version} $R0
 
 	; Push the result onto the stack
-	Push $R1
+	Push $R0
 
 	; Restore registers
-	Exch
-	Pop $R2
-	Exch
-	Pop $R1
 	Exch
 	Pop $R0
 
 	; Set result
 	Pop ${Result}
-
 !macroend
 
+; DEPRICATED
+; Backwards compatible macro to get the currently installed AspNetCore runtime version
+;
+; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+; \param[out] Result The full version number of the latest version - e.g. 6.0.7
 !macro AspNetCoreGetInstalledVersion Version Result
-	!define DNC_INS_ID ${__LINE__}
-
 	; Save registers
 	Push $R0
-	Push $R1
-	Push $R2
 
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	DetailPrint "Checking installed version of AspNetCore $R0"
-
-	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*AspNet.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
-	!insertmacro ExecPSScript $R1 $R1
-	; $R1 contains highest installed version, e.g. 6.0.7
-
-	${TrimNewLines} $R1 $R1
-
-	; If there is an installed version it should start with the same two "words" as the input version,
-	; otherwise assume we got an error response
-
-	; todo improve this simple test which checks there are at least 3 "words" separated by periods
-	${WordFind} $R1 "." "E#" $R2
-	IfErrors error_${DNC_INS_ID}
-	; $R2 contains number of version parts in R1 (dot separated words = version parts)
-
-	; If less than 3 parts, or more than 4 parts, error
-	IntCmp $R2 3 0 error_${DNC_INS_ID}
-	IntCmp $R2 4 0 0 error_${DNC_INS_ID}
-
-	; todo more error handling here / validation
-
-	; Seems to be OK, skip the "set to blank string" error handler
-	Goto end_${DNC_INS_ID}
-
-	error_${DNC_INS_ID}:
-	StrCpy $R1 "" ; Set result to blank string if any error occurs (means not installed)
-
-	end_${DNC_INS_ID}:
-	!undef DNC_INS_ID
+	!insertmacro RuntimeGetInstalledVersion "AspNetCore" ${Version} $R0
 
 	; Push the result onto the stack
-	Push $R1
+	Push $R0
 
 	; Restore registers
-	Exch
-	Pop $R2
-	Exch
-	Pop $R1
 	Exch
 	Pop $R0
 
 	; Set result
 	Pop ${Result}
-
 !macroend
 
-!macro WindowsDesktopGetInstalledVersion Version Result
-	!define DNC_INS_ID ${__LINE__}
-
-	; Save registers
-	Push $R0
-	Push $R1
-	Push $R2
-
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	DetailPrint "Checking installed version of WindowsDesktop runtime $R0"
-
-	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*WindowsDesktop.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
-	!insertmacro ExecPSScript $R1 $R1
-	; $R1 contains highest installed version, e.g. 6.0.7
-
-	${TrimNewLines} $R1 $R1
-
-	; If there is an installed version it should start with the same two "words" as the input version,
-	; otherwise assume we got an error response
-
-	; todo improve this simple test which checks there are at least 3 "words" separated by periods
-	${WordFind} $R1 "." "E#" $R2
-	IfErrors error_${DNC_INS_ID}
-	; $R2 contains number of version parts in R1 (dot separated words = version parts)
-
-	; If less than 3 parts, or more than 4 parts, error
-	IntCmp $R2 3 0 error_${DNC_INS_ID}
-	IntCmp $R2 4 0 0 error_${DNC_INS_ID}
-
-	; todo more error handling here / validation
-
-	; Seems to be OK, skip the "set to blank string" error handler
-	Goto end_${DNC_INS_ID}
-
-	error_${DNC_INS_ID}:
-	StrCpy $R1 "" ; Set result to blank string if any error occurs (means not installed)
-
-	end_${DNC_INS_ID}:
-	!undef DNC_INS_ID
-
-	; Push the result onto the stack
-	Push $R1
-
-	; Restore registers
-	Exch
-	Pop $R2
-	Exch
-	Pop $R1
-	Exch
-	Pop $R0
-
-	; Set result
-	Pop ${Result}
-
-!macroend
-
+; DEPRICATED
+; Backwards compatible macro to install a certain WindowsDesktop runtime version
+;
+; \param Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
 !macro DotNetCoreInstallVersion Version
-
-	; Save registers
-	Push $R0
-	Push $R1
-	Push $R2
-	Push $R3
-
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	${If} ${IsNativeAMD64}
-		StrCpy $R3 "x64"
-	${ElseIf} ${IsNativeARM64}
-		StrCpy $R3 "arm64"
-	${ElseIf} ${IsNativeIA32}
-		StrCpy $R3 "x86"
-	${Else}
-		StrCpy $R3 "unknown"
-	${EndIf}
-
-	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/dotnet-runtime-$R0-win-$R3.exe
-
-	DetailPrint "Downloading dotnet $R0 from $R1"
-
-	; Create destination file
-	GetTempFileName $R2
-	nsExec::Exec 'cmd.exe /c rename "$R2" "$R2.exe"'	; Not using Rename to avoid spam in details log
-	Pop $R3 ; Pop exit code
-	StrCpy $R2 "$R2.exe"
-	
-	; Fetch runtime installer
-	; todo error handling in the PS script? so we can check for errors here
-	StrCpy $R1 "Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\" -OutFile $\"$R2$\""
-	!insertmacro ExecPSScript $R1 $R1
-	; $R1 contains powershell script result
-
-	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
-	ifErrors +3 0
-	DetailPrint "Dotnet installer $R0 not found."
-	Goto +10
-
-	; todo error handling for PS result, verify download result
-
-	
-	IfFileExists $R2 +3, 0
-	DetailPrint "Dotnet installer did not download."
-	Goto +7
-
-	DetailPrint "Download complete"
-
-	DetailPrint "Installing dotnet $R0"
-	ExecWait "$\"$R2$\" /install /quiet /norestart" $R1
-	DetailPrint "Installer completed (Result: $R1)"
-
-	nsExec::Exec 'cmd.exe /c del "$R2"'	; Not using Delete to avoid spam in details log
-	Pop $R3 ; Pop exit code
-
-	; Error checking? Verify install result?
-
-	; Restore registers
-	Pop $R3
-	Pop $R2
-	Pop $R1
-	Pop $R0
-
+	!insertmacro RuntimeInstallVersion "WindowsDesktop" ${Version} ""
 !macroend
 
+; DEPRICATED
+; Backwards compatible macro to install a certain AspNetCore runtime version
+;
+; \param Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
 !macro AspNetCoreInstallVersion Version
-
-	; Save registers
-	Push $R0
-	Push $R1
-	Push $R2
-	Push $R3
-
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	${If} ${IsNativeAMD64}
-		StrCpy $R3 "x64"
-	${ElseIf} ${IsNativeARM64}
-		StrCpy $R3 "arm64"
-	${ElseIf} ${IsNativeIA32}
-		StrCpy $R3 "x86"
-	${Else}
-		StrCpy $R3 "unknown"
-	${EndIf}
-
-	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R0/dotnet-hosting-$R0-win.exe
-
-	DetailPrint "Downloading AspNetCore $R0 from $R1"
-
-	; Create destination file
-	GetTempFileName $R2
-	nsExec::Exec 'cmd.exe /c rename "$R2" "$R2.exe"'	; Not using Rename to avoid spam in details log
-	Pop $R3 ; Pop exit code
-	StrCpy $R2 "$R2.exe"
-	
-	; Fetch runtime installer
-	; todo error handling in the PS script? so we can check for errors here
-	StrCpy $R1 "Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\" -OutFile $\"$R2$\""
-	!insertmacro ExecPSScript $R1 $R1
-	; $R1 contains powershell script result
-
-	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
-	ifErrors +3 0
-	DetailPrint "AspNetCore installer $R0 not found."
-	Goto +10
-
-	; todo error handling for PS result, verify download result
-
-	
-	IfFileExists $R2 +3, 0
-	DetailPrint "AspNetCore installer did not download."
-	Goto +7
-
-	DetailPrint "Download complete"
-
-	DetailPrint "Installing AspNetCore $R0"
-	ExecWait "$\"$R2$\" /install /quiet /norestart" $R1
-	DetailPrint "Installer completed (Result: $R1)"
-
-	nsExec::Exec 'cmd.exe /c del "$R2"'	; Not using Delete to avoid spam in details log
-	Pop $R3 ; Pop exit code
-
-	; Error checking? Verify install result?
-
-	; Restore registers
-	Pop $R3
-	Pop $R2
-	Pop $R1
-	Pop $R0
-
+	!insertmacro RuntimeInstallVersion "AspNetCore" ${Version} ""
 !macroend
 
-!macro WindowsDesktopInstallVersion Version
+;-------------------------------------------------------------------------------------------------
+; Helper Macros and Functions
+;-------------------------------------------------------------------------------------------------
 
-	; Save registers
-	Push $R0
-	Push $R1
-	Push $R2
-	Push $R3
-
-	; Push and pop parameters so we don't have conflicts if parameters are $R#
-	Push ${Version}
-	Pop $R0 ; Version
-
-	${If} ${IsNativeAMD64}
-		StrCpy $R3 "x64"
-	${ElseIf} ${IsNativeARM64}
-		StrCpy $R3 "arm64"
-	${ElseIf} ${IsNativeIA32}
-		StrCpy $R3 "x86"
-	${Else}
-		StrCpy $R3 "unknown"
-	${EndIf}
-
-	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
-
-	; For dotnet versions less than 5 the WindowsDesktop runtime has a different path
-	${WordFind} $R0 "." "+1" $R2
-	IntCmp $R2 5 +2 0 +2
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
-
-	DetailPrint "Downloading WindowsDesktop runtime $R0 from $R1"
-
-	; Create destination file
-	GetTempFileName $R2
-	nsExec::Exec 'cmd.exe /c rename "$R2" "$R2.exe"'	; Not using Rename to avoid spam in details log
-	Pop $R3 ; Pop exit code
-	StrCpy $R2 "$R2.exe"
-	
-	; Fetch runtime installer
-	; todo error handling in the PS script? so we can check for errors here
-	StrCpy $R1 "Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\" -OutFile $\"$R2$\""
-	!insertmacro ExecPSScript $R1 $R1
-	; $R1 contains powershell script result
-
-	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
-	ifErrors +3 0
-	DetailPrint "WindowsDesktop runtime installer $R0 not found."
-	Goto +10
-
-	; todo error handling for PS result, verify download result
-
-	
-	IfFileExists $R2 +3, 0
-	DetailPrint "WindowsDesktop runtime installer did not download."
-	Goto +7
-
-	DetailPrint "Download complete"
-
-	DetailPrint "Installing WindowsDesktop runtime $R0"
-	ExecWait "$\"$R2$\" /install /quiet /norestart" $R1
-	DetailPrint "Installer completed (Result: $R1)"
-
-	nsExec::Exec 'cmd.exe /c del "$R2"'	; Not using Delete to avoid spam in details log
-	Pop $R3 ; Pop exit code
-
-	; Error checking? Verify install result?
-
-	; Restore registers
-	Pop $R3
-	Pop $R2
-	Pop $R1
-	Pop $R0
-
-!macroend
-
-; below is adapted from https://nsis.sourceforge.io/PowerShell_support but avoids using the plugin
+; Below is adapted from https://nsis.sourceforge.io/PowerShell_support but avoids using the plugin
 ; directory in favour of a temp file and providing a return variable rather than returning on the
 ; stack. Methods renamed to avoid conflicting with use of the original macros
 
@@ -757,5 +557,4 @@ Function ExecPSScriptFileFn
 	; Stack contains script output only, which we leave as the function result
 
 FunctionEnd
-
 !endif

--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -69,6 +69,60 @@
 
 !macroend
 
+!macro CheckAspNetCore Version
+
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Version}
+	Pop $R0 ; Version
+
+	!define ID ${__LINE__}
+
+	; Check current installed version
+	!insertmacro AspNetCoreGetInstalledVersion $R0 $R1
+
+	; If $R1 is blank then there is no version installed, otherwise it is installed
+	; todo in future we might want to support "must be at least 6.0.7", for now we only deal with "yes/no" for a major version (e.g. 6.0)
+	StrCmp $R1 "" notinstalled_${ID}
+	DetailPrint "AspNetCore version $R1 already installed"
+	Goto end_${ID}
+
+	notinstalled_${ID}:
+	DetailPrint "AspNetCore $R0 is not installed"
+
+	!insertmacro AspNetCoreGetLatestVersion $R0 $R1
+	DetailPrint "Latest Version of $R0 is $R1"
+
+
+	; Get number of input digits
+	; ${WordFind} $R1 "." "#" $R2
+	; DetailPrint "version parts count is $R2"
+
+	; ${WordFind} $R1 "." "+1" $R2
+	; DetailPrint "version part 1 is $R2"
+
+	; ${WordFind} $R1 "." "+2" $R2
+	; DetailPrint "version part 2 is $R2"
+
+	; ${WordFind} $R1 "." "+3" $R2
+	; DetailPrint "version part 3 is $R2"
+
+	!insertmacro AspNetCoreInstallVersion $R1
+
+	end_${ID}:
+	!undef ID
+
+	; Restore registers
+	Pop $R2
+	Pop $R1
+	Pop $R0
+
+!macroend
+
 
 
 ; Gets the latest version of the runtime for a specified dotnet version. This uses the same endpoint
@@ -115,6 +169,52 @@
 
 !macroend
 
+; Gets the latest version of the runtime for a specified dotnet version. This uses the same endpoint
+; as the dotnet-install scripts to determine the latest full version of a dotnet version
+;
+; \param[in] Version The desired dotnet core runtime version as a 2 digit version. e.g. 3.1, 6.0, 7.0
+; \param[out] Result The full version number of the latest version - e.g. 6.0.7
+!macro AspNetCoreGetLatestVersion Version Result
+
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Version}
+	Pop $R0 ; Version
+
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R0/latest.version
+	DetailPrint "Querying latest version of AspNetCore $R0 from $R1"
+
+	; Fetch latest version of the desired dotnet version
+	; todo error handling in the PS script? so we can check for errors here
+	StrCpy $R2 "Write-Host (Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\").Content;"
+	!insertmacro DotNetCorePSExec $R2 $R2
+	; $R2 contains latest version, e.g. 6.0.7
+
+	; todo error handling here
+
+	; Push the result onto the stack
+	${TrimNewLines} $R2 $R2
+	Push $R2
+
+	; Restore registers
+	Exch
+	Pop $R2
+	Exch
+	Pop $R1
+	Exch
+	Pop $R0
+
+	; Set result
+	Pop ${Result}
+
+!macroend
+
+
+
 !macro DotNetCoreGetInstalledVersion Version Result
 	!define DNC_INS_ID ${__LINE__}
 
@@ -130,6 +230,65 @@
 	DetailPrint "Checking installed version of dotnet $R0"
 
 	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*WindowsDesktop.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
+	!insertmacro DotNetCorePSExec $R1 $R1
+	; $R1 contains highest installed version, e.g. 6.0.7
+
+	${TrimNewLines} $R1 $R1
+
+	; If there is an installed version it should start with the same two "words" as the input version,
+	; otherwise assume we got an error response
+
+	; todo improve this simple test which checks there are at least 3 "words" separated by periods
+	${WordFind} $R1 "." "E#" $R2
+	IfErrors error_${DNC_INS_ID}
+	; $R2 contains number of version parts in R1 (dot separated words = version parts)
+
+	; If less than 3 parts, or more than 4 parts, error
+	IntCmp $R2 3 0 error_${DNC_INS_ID}
+	IntCmp $R2 4 0 0 error_${DNC_INS_ID}
+
+	; todo more error handling here / validation
+
+	; Seems to be OK, skip the "set to blank string" error handler
+	Goto end_${DNC_INS_ID}
+
+	error_${DNC_INS_ID}:
+	StrCpy $R1 "" ; Set result to blank string if any error occurs (means not installed)
+
+	end_${DNC_INS_ID}:
+	!undef DNC_INS_ID
+
+	; Push the result onto the stack
+	Push $R1
+
+	; Restore registers
+	Exch
+	Pop $R2
+	Exch
+	Pop $R1
+	Exch
+	Pop $R0
+
+	; Set result
+	Pop ${Result}
+
+!macroend
+
+!macro AspNetCoreGetInstalledVersion Version Result
+	!define DNC_INS_ID ${__LINE__}
+
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Version}
+	Pop $R0 ; Version
+
+	DetailPrint "Checking installed version of AspNetCore $R0"
+
+	StrCpy $R1 "dotnet --list-runtimes | % { if($$_ -match $\".*AspNet.*($R0.\d+).*$\") { $$matches[1] } } | Sort-Object {[int]($$_ -replace '\d.\d.(\d+)', '$$1')} -Descending | Select-Object -first 1"
 	!insertmacro DotNetCorePSExec $R1 $R1
 	; $R1 contains highest installed version, e.g. 6.0.7
 
@@ -233,6 +392,81 @@
 	DetailPrint "Download complete"
 
 	DetailPrint "Installing dotnet $R0"
+	ExecWait "$\"$R2$\" /install /quiet /norestart" $R1
+	DetailPrint "Installer completed (Result: $R1)"
+
+	nsExec::Exec 'cmd.exe /c del "$R2"'	; Not using Delete to avoid spam in details log
+	Pop $R3 ; Pop exit code
+
+	; Error checking? Verify install result?
+
+	; Restore registers
+	Pop $R3
+	Pop $R2
+	Pop $R1
+	Pop $R0
+
+!macroend
+
+!macro AspNetCoreInstallVersion Version
+
+	; Save registers
+	Push $R0
+	Push $R1
+	Push $R2
+	Push $R3
+
+	; Push and pop parameters so we don't have conflicts if parameters are $R#
+	Push ${Version}
+	Pop $R0 ; Version
+
+	${If} ${IsNativeAMD64}
+		StrCpy $R3 "x64"
+	${ElseIf} ${IsNativeARM64}
+		StrCpy $R3 "arm64"
+	${ElseIf} ${IsNativeIA32}
+		StrCpy $R3 "x86"
+	${Else}
+		StrCpy $R3 "unknown"
+	${EndIf}
+
+	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R0/dotnet-hosting-$R0-win.exe
+
+	; For dotnet versions less than 5 the WindowsDesktop runtime has a different path
+	${WordFind} $R0 "." "+1" $R2
+	IntCmp $R2 5 +2 0 +2
+	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$R0/dotnet-hosting-$R0-win.exe
+
+	DetailPrint "Downloading dotnet $R0 from $R1"
+
+	; Create destination file
+	GetTempFileName $R2
+	nsExec::Exec 'cmd.exe /c rename "$R2" "$R2.exe"'	; Not using Rename to avoid spam in details log
+	Pop $R3 ; Pop exit code
+	StrCpy $R2 "$R2.exe"
+	
+	; Fetch runtime installer
+	; todo error handling in the PS script? so we can check for errors here
+	StrCpy $R1 "Invoke-WebRequest -UseBasicParsing -URI $\"$R1$\" -OutFile $\"$R2$\""
+	!insertmacro DotNetCorePSExec $R1 $R1
+	; $R1 contains powershell script result
+
+	${WordFind} $R1 "BlobNotFound" "E+1{" $R3
+	ifErrors +3 0
+	DetailPrint "AspNetCore installer $R0 not found."
+	Goto +10
+
+	; todo error handling for PS result, verify download result
+
+	
+	IfFileExists $R2 +3, 0
+	DetailPrint "AspNetCore installer did not download."
+	Goto +7
+
+	DetailPrint "Download complete"
+
+	DetailPrint "Installing AspNetCore $R0"
 	ExecWait "$\"$R2$\" /install /quiet /norestart" $R1
 	DetailPrint "Installer completed (Result: $R1)"
 

--- a/test/testscript.nsi
+++ b/test/testscript.nsi
@@ -49,6 +49,29 @@ Section "Dummy Section" SecDummy
   !insertmacro CheckDotNetCore 3.1
   !insertmacro CheckDotNetCore 5.0
   !insertmacro CheckDotNetCore 6.0
+  
+  
+  !insertmacro AspNetCoreGetLatestVersion 3.1 $0
+  DetailPrint "Latest Version of 3.1 is $0"
+
+  !insertmacro AspNetCoreGetInstalledVersion 3.1 $0
+  DetailPrint "Installed Version of 3.1 is $0"
+
+  !insertmacro AspNetCoreGetLatestVersion 5.0 $0
+  DetailPrint "Latest Version of 5.0 is $0"
+
+  !insertmacro AspNetCoreGetInstalledVersion 5.0 $0
+  DetailPrint "Installed Version of 5.0 is $0"
+
+  !insertmacro AspNetCoreGetLatestVersion 6.0 $0
+  DetailPrint "Latest Version of 6.0 is $0"
+
+  !insertmacro AspNetCoreGetInstalledVersion 6.0 $0
+  DetailPrint "Installed Version of 6.0 is $0"
+   
+  !insertmacro CheckAspNetCore 3.1
+  !insertmacro CheckAspNetCore 5.0
+  !insertmacro CheckAspNetCore 6.0
 
   WriteRegStr HKCU "Software\DotNetCore Test" "" $INSTDIR
   WriteUninstaller "$INSTDIR\Uninstall.exe"

--- a/test/testscript.nsi
+++ b/test/testscript.nsi
@@ -21,12 +21,17 @@ RequestExecutionLevel admin
   
 !insertmacro MUI_LANGUAGE "English"
 
-;--------------------------------
+; -----------------------------------------------------------
 ;Installer Sections
+; -----------------------------------------------------------
 
 Section "Dummy Section" SecDummy
 
   SetOutPath "$INSTDIR"
+
+; -----------------------------------------------------------
+; DotNetCore
+; -----------------------------------------------------------
 
   !insertmacro RuntimeGetLatestVersion "DotNetCore" 9.0 $0
   DetailPrint "Latest Version of DotNetCore 9.0 is $0"
@@ -37,6 +42,8 @@ Section "Dummy Section" SecDummy
   !insertmacro CheckRuntime "DotNetCore" 9.0 ""
 
 ; -----------------------------------------------------------
+; AspNetCore
+; -----------------------------------------------------------
 
   !insertmacro RuntimeGetLatestVersion "AspNetCore" 9.0 $0
   DetailPrint "Latest Version of AspNetCore 9.0 is $0"
@@ -46,6 +53,8 @@ Section "Dummy Section" SecDummy
 
   !insertmacro CheckRuntime "AspNetCore" 9.0 ""
   
+; -----------------------------------------------------------
+; WindowsDesktop
 ; -----------------------------------------------------------
 
   !insertmacro RuntimeGetLatestVersion "WindowsDesktop" 3.1 $0
@@ -63,36 +72,25 @@ Section "Dummy Section" SecDummy
   !insertmacro CheckRuntime "WindowsDesktop" 3.1 ""
   !insertmacro CheckRuntime "WindowsDesktop" 9.0 ""
 
-  ; !insertmacro DotNetCoreGetLatestVersion 6.0 $0
-  ; DetailPrint "Latest Version of 6.0 is $0"
+; -----------------------------------------------------------
+; Backwards Compatibility
+; -----------------------------------------------------------
 
-  ; !insertmacro DotNetCoreGetInstalledVersion 6.0 $0
-  ; DetailPrint "Installed Version of 6.0 is $0"
+  !insertmacro DotNetCoreGetLatestVersion 6.0 $0
+  DetailPrint "Latest Version of 6.0 is $0"
 
-  ; !insertmacro CheckDotNetCore 6.0
+  !insertmacro DotNetCoreGetInstalledVersion 6.0 $0
+  DetailPrint "Installed Version of 6.0 is $0"
 
-  ; !insertmacro AspNetCoreGetLatestVersion 6.0 $0
-  ; DetailPrint "Latest Version of 6.0 is $0"
+  !insertmacro CheckDotNetCore 6.0
 
-  ; !insertmacro AspNetCoreGetInstalledVersion 6.0 $0
-  ; DetailPrint "Installed Version of 6.0 is $0"
+  !insertmacro AspNetCoreGetLatestVersion 6.0 $0
+  DetailPrint "Latest Version of 6.0 is $0"
 
-  ; !insertmacro CheckAspNetCore 6.0
-  
-  ; !insertmacro WindowsDesktopGetLatestVersion 3.1 $0
-  ; DetailPrint "Latest Version of 3.1 is $0"
+  !insertmacro AspNetCoreGetInstalledVersion 6.0 $0
+  DetailPrint "Installed Version of 6.0 is $0"
 
-  ; !insertmacro WindowsDesktopGetInstalledVersion 3.1 $0
-  ; DetailPrint "Installed Version of 3.1 is $0"
-
-  ; !insertmacro WindowsDesktopGetLatestVersion 6.0 $0
-  ; DetailPrint "Latest Version of 6.0 is $0"
-
-  ; !insertmacro WindowsDesktopGetInstalledVersion 6.0 $0
-  ; DetailPrint "Installed Version of 6.0 is $0"
-   
-  ; !insertmacro CheckWindowsDesktop 3.1
-  ; !insertmacro CheckWindowsDesktop 6.0
+  !insertmacro CheckAspNetCore 6.0
 
   WriteRegStr HKCU "Software\DotNetCore Test" "" $INSTDIR
   WriteUninstaller "$INSTDIR\Uninstall.exe"

--- a/test/testscript.nsi
+++ b/test/testscript.nsi
@@ -28,72 +28,13 @@ Section "Dummy Section" SecDummy
 
   SetOutPath "$INSTDIR"
 
-  !insertmacro DotNetCoreGetLatestVersion 3.1 $0
-  DetailPrint "Latest Version of 3.1 is $0"
-
-  !insertmacro DotNetCoreGetInstalledVersion 3.1 $0
-  DetailPrint "Installed Version of 3.1 is $0"
-
-  !insertmacro DotNetCoreGetLatestVersion 5.0 $0
-  DetailPrint "Latest Version of 5.0 is $0"
-
-  !insertmacro DotNetCoreGetInstalledVersion 5.0 $0
-  DetailPrint "Installed Version of 5.0 is $0"
-
-  !insertmacro DotNetCoreGetLatestVersion 6.0 $0
-  DetailPrint "Latest Version of 6.0 is $0"
-
-  !insertmacro DotNetCoreGetInstalledVersion 6.0 $0
-  DetailPrint "Installed Version of 6.0 is $0"
-
-  !insertmacro DotNetCoreGetLatestVersion 7.0 $0
-  DetailPrint "Latest Version of 7.0 is $0"
-
-  !insertmacro DotNetCoreGetInstalledVersion 7.0 $0
-  DetailPrint "Installed Version of 7.0 is $0"
-
   !insertmacro DotNetCoreGetLatestVersion 8.0 $0
   DetailPrint "Latest Version of 8.0 is $0"
 
   !insertmacro DotNetCoreGetInstalledVersion 8.0 $0
   DetailPrint "Installed Version of 8.0 is $0"
 
-  !insertmacro DotNetCoreGetLatestVersion 9.0 $0
-  DetailPrint "Latest Version of 9.0 is $0"
-
-  !insertmacro DotNetCoreGetInstalledVersion 9.0 $0
-  DetailPrint "Installed Version of 9.0 is $0"
-
-  !insertmacro CheckDotNetCore 3.1
-  !insertmacro CheckDotNetCore 5.0
-  !insertmacro CheckDotNetCore 6.0
-  !insertmacro CheckDotNetCore 7.0
   !insertmacro CheckDotNetCore 8.0
-  !insertmacro CheckDotNetCore 9.0
-  
-  !insertmacro AspNetCoreGetLatestVersion 3.1 $0
-  DetailPrint "Latest Version of 3.1 is $0"
-
-  !insertmacro AspNetCoreGetInstalledVersion 3.1 $0
-  DetailPrint "Installed Version of 3.1 is $0"
-
-  !insertmacro AspNetCoreGetLatestVersion 5.0 $0
-  DetailPrint "Latest Version of 5.0 is $0"
-
-  !insertmacro AspNetCoreGetInstalledVersion 5.0 $0
-  DetailPrint "Installed Version of 5.0 is $0"
-
-  !insertmacro AspNetCoreGetLatestVersion 6.0 $0
-  DetailPrint "Latest Version of 6.0 is $0"
-
-  !insertmacro AspNetCoreGetInstalledVersion 6.0 $0
-  DetailPrint "Installed Version of 6.0 is $0"
-
-  !insertmacro AspNetCoreGetLatestVersion 7.0 $0
-  DetailPrint "Latest Version of 7.0 is $0"
-
-  !insertmacro AspNetCoreGetInstalledVersion 7.0 $0
-  DetailPrint "Installed Version of 7.0 is $0"
 
   !insertmacro AspNetCoreGetLatestVersion 8.0 $0
   DetailPrint "Latest Version of 8.0 is $0"
@@ -101,18 +42,7 @@ Section "Dummy Section" SecDummy
   !insertmacro AspNetCoreGetInstalledVersion 8.0 $0
   DetailPrint "Installed Version of 8.0 is $0"
 
-  !insertmacro AspNetCoreGetLatestVersion 9.0 $0
-  DetailPrint "Latest Version of 9.0 is $0"
-
-  !insertmacro AspNetCoreGetInstalledVersion 9.0 $0
-  DetailPrint "Installed Version of 9.0 is $0"
-   
-  !insertmacro CheckAspNetCore 3.1
-  !insertmacro CheckAspNetCore 5.0
-  !insertmacro CheckAspNetCore 6.0
-  !insertmacro CheckAspNetCore 7.0
   !insertmacro CheckAspNetCore 8.0
-  !insertmacro CheckAspNetCore 9.0
   
   !insertmacro WindowsDesktopGetLatestVersion 3.1 $0
   DetailPrint "Latest Version of 3.1 is $0"
@@ -120,42 +50,14 @@ Section "Dummy Section" SecDummy
   !insertmacro WindowsDesktopGetInstalledVersion 3.1 $0
   DetailPrint "Installed Version of 3.1 is $0"
 
-  !insertmacro WindowsDesktopGetLatestVersion 5.0 $0
-  DetailPrint "Latest Version of 5.0 is $0"
-
-  !insertmacro WindowsDesktopGetInstalledVersion 5.0 $0
-  DetailPrint "Installed Version of 5.0 is $0"
-
-  !insertmacro WindowsDesktopGetLatestVersion 6.0 $0
-  DetailPrint "Latest Version of 6.0 is $0"
-
-  !insertmacro WindowsDesktopGetInstalledVersion 6.0 $0
-  DetailPrint "Installed Version of 6.0 is $0"
-
-  !insertmacro WindowsDesktopGetLatestVersion 7.0 $0
-  DetailPrint "Latest Version of 7.0 is $0"
-
-  !insertmacro WindowsDesktopGetInstalledVersion 7.0 $0
-  DetailPrint "Installed Version of 7.0 is $0"
-
   !insertmacro WindowsDesktopGetLatestVersion 8.0 $0
   DetailPrint "Latest Version of 8.0 is $0"
 
   !insertmacro WindowsDesktopGetInstalledVersion 8.0 $0
   DetailPrint "Installed Version of 8.0 is $0"
-
-  !insertmacro WindowsDesktopGetLatestVersion 9.0 $0
-  DetailPrint "Latest Version of 9.0 is $0"
-
-  !insertmacro WindowsDesktopGetInstalledVersion 9.0 $0
-  DetailPrint "Installed Version of 9.0 is $0"
    
   !insertmacro CheckWindowsDesktop 3.1
-  !insertmacro CheckWindowsDesktop 5.0
-  !insertmacro CheckWindowsDesktop 6.0
-  !insertmacro CheckWindowsDesktop 7.0
   !insertmacro CheckWindowsDesktop 8.0
-  !insertmacro CheckWindowsDesktop 9.0
 
   WriteRegStr HKCU "Software\DotNetCore Test" "" $INSTDIR
   WriteUninstaller "$INSTDIR\Uninstall.exe"

--- a/test/testscript.nsi
+++ b/test/testscript.nsi
@@ -28,36 +28,71 @@ Section "Dummy Section" SecDummy
 
   SetOutPath "$INSTDIR"
 
-  !insertmacro DotNetCoreGetLatestVersion 8.0 $0
-  DetailPrint "Latest Version of 8.0 is $0"
+  !insertmacro RuntimeGetLatestVersion "DotNetCore" 9.0 $0
+  DetailPrint "Latest Version of DotNetCore 9.0 is $0"
 
-  !insertmacro DotNetCoreGetInstalledVersion 8.0 $0
-  DetailPrint "Installed Version of 8.0 is $0"
+  !insertmacro RuntimeGetInstalledVersion "DotNetCore" 9.0 $0
+  DetailPrint "Installed Version of DotNetCore 9.0 is $0"
 
-  !insertmacro CheckDotNetCore 8.0
+  !insertmacro CheckRuntime "DotNetCore" 9.0 ""
 
-  !insertmacro AspNetCoreGetLatestVersion 8.0 $0
-  DetailPrint "Latest Version of 8.0 is $0"
+; -----------------------------------------------------------
 
-  !insertmacro AspNetCoreGetInstalledVersion 8.0 $0
-  DetailPrint "Installed Version of 8.0 is $0"
+  !insertmacro RuntimeGetLatestVersion "AspNetCore" 9.0 $0
+  DetailPrint "Latest Version of AspNetCore 9.0 is $0"
 
-  !insertmacro CheckAspNetCore 8.0
+  !insertmacro RuntimeGetInstalledVersion "AspNetCore" 9.0 $0
+  DetailPrint "Installed Version of AspNetCore 9.0 is $0"
+
+  !insertmacro CheckRuntime "AspNetCore" 9.0 ""
   
-  !insertmacro WindowsDesktopGetLatestVersion 3.1 $0
-  DetailPrint "Latest Version of 3.1 is $0"
+; -----------------------------------------------------------
 
-  !insertmacro WindowsDesktopGetInstalledVersion 3.1 $0
-  DetailPrint "Installed Version of 3.1 is $0"
+  !insertmacro RuntimeGetLatestVersion "WindowsDesktop" 3.1 $0
+  DetailPrint "Latest Version of WindowsDesktop 3.1 is $0"
 
-  !insertmacro WindowsDesktopGetLatestVersion 8.0 $0
-  DetailPrint "Latest Version of 8.0 is $0"
+  !insertmacro RuntimeGetInstalledVersion "WindowsDesktop" 3.1 $0
+  DetailPrint "Installed Version of WindowsDesktop 3.1 is $0"
 
-  !insertmacro WindowsDesktopGetInstalledVersion 8.0 $0
-  DetailPrint "Installed Version of 8.0 is $0"
+  !insertmacro RuntimeGetLatestVersion "WindowsDesktop" 9.0 $0
+  DetailPrint "Latest Version of WindowsDesktop 9.0 is $0"
+
+  !insertmacro RuntimeGetInstalledVersion "WindowsDesktop" 9.0 $0
+  DetailPrint "Installed Version of WindowsDesktop 9.0 is $0"
    
-  !insertmacro CheckWindowsDesktop 3.1
-  !insertmacro CheckWindowsDesktop 8.0
+  !insertmacro CheckRuntime "WindowsDesktop" 3.1 ""
+  !insertmacro CheckRuntime "WindowsDesktop" 9.0 ""
+
+  ; !insertmacro DotNetCoreGetLatestVersion 6.0 $0
+  ; DetailPrint "Latest Version of 6.0 is $0"
+
+  ; !insertmacro DotNetCoreGetInstalledVersion 6.0 $0
+  ; DetailPrint "Installed Version of 6.0 is $0"
+
+  ; !insertmacro CheckDotNetCore 6.0
+
+  ; !insertmacro AspNetCoreGetLatestVersion 6.0 $0
+  ; DetailPrint "Latest Version of 6.0 is $0"
+
+  ; !insertmacro AspNetCoreGetInstalledVersion 6.0 $0
+  ; DetailPrint "Installed Version of 6.0 is $0"
+
+  ; !insertmacro CheckAspNetCore 6.0
+  
+  ; !insertmacro WindowsDesktopGetLatestVersion 3.1 $0
+  ; DetailPrint "Latest Version of 3.1 is $0"
+
+  ; !insertmacro WindowsDesktopGetInstalledVersion 3.1 $0
+  ; DetailPrint "Installed Version of 3.1 is $0"
+
+  ; !insertmacro WindowsDesktopGetLatestVersion 6.0 $0
+  ; DetailPrint "Latest Version of 6.0 is $0"
+
+  ; !insertmacro WindowsDesktopGetInstalledVersion 6.0 $0
+  ; DetailPrint "Installed Version of 6.0 is $0"
+   
+  ; !insertmacro CheckWindowsDesktop 3.1
+  ; !insertmacro CheckWindowsDesktop 6.0
 
   WriteRegStr HKCU "Software\DotNetCore Test" "" $INSTDIR
   WriteUninstaller "$INSTDIR\Uninstall.exe"

--- a/test/testscript.nsi
+++ b/test/testscript.nsi
@@ -46,10 +46,30 @@ Section "Dummy Section" SecDummy
   !insertmacro DotNetCoreGetInstalledVersion 6.0 $0
   DetailPrint "Installed Version of 6.0 is $0"
 
+  !insertmacro DotNetCoreGetLatestVersion 7.0 $0
+  DetailPrint "Latest Version of 7.0 is $0"
+
+  !insertmacro DotNetCoreGetInstalledVersion 7.0 $0
+  DetailPrint "Installed Version of 7.0 is $0"
+
+  !insertmacro DotNetCoreGetLatestVersion 8.0 $0
+  DetailPrint "Latest Version of 8.0 is $0"
+
+  !insertmacro DotNetCoreGetInstalledVersion 8.0 $0
+  DetailPrint "Installed Version of 8.0 is $0"
+
+  !insertmacro DotNetCoreGetLatestVersion 9.0 $0
+  DetailPrint "Latest Version of 9.0 is $0"
+
+  !insertmacro DotNetCoreGetInstalledVersion 9.0 $0
+  DetailPrint "Installed Version of 9.0 is $0"
+
   !insertmacro CheckDotNetCore 3.1
   !insertmacro CheckDotNetCore 5.0
   !insertmacro CheckDotNetCore 6.0
-  
+  !insertmacro CheckDotNetCore 7.0
+  !insertmacro CheckDotNetCore 8.0
+  !insertmacro CheckDotNetCore 9.0
   
   !insertmacro AspNetCoreGetLatestVersion 3.1 $0
   DetailPrint "Latest Version of 3.1 is $0"
@@ -68,10 +88,74 @@ Section "Dummy Section" SecDummy
 
   !insertmacro AspNetCoreGetInstalledVersion 6.0 $0
   DetailPrint "Installed Version of 6.0 is $0"
+
+  !insertmacro AspNetCoreGetLatestVersion 7.0 $0
+  DetailPrint "Latest Version of 7.0 is $0"
+
+  !insertmacro AspNetCoreGetInstalledVersion 7.0 $0
+  DetailPrint "Installed Version of 7.0 is $0"
+
+  !insertmacro AspNetCoreGetLatestVersion 8.0 $0
+  DetailPrint "Latest Version of 8.0 is $0"
+
+  !insertmacro AspNetCoreGetInstalledVersion 8.0 $0
+  DetailPrint "Installed Version of 8.0 is $0"
+
+  !insertmacro AspNetCoreGetLatestVersion 9.0 $0
+  DetailPrint "Latest Version of 9.0 is $0"
+
+  !insertmacro AspNetCoreGetInstalledVersion 9.0 $0
+  DetailPrint "Installed Version of 9.0 is $0"
    
   !insertmacro CheckAspNetCore 3.1
   !insertmacro CheckAspNetCore 5.0
   !insertmacro CheckAspNetCore 6.0
+  !insertmacro CheckAspNetCore 7.0
+  !insertmacro CheckAspNetCore 8.0
+  !insertmacro CheckAspNetCore 9.0
+  
+  !insertmacro WindowsDesktopGetLatestVersion 3.1 $0
+  DetailPrint "Latest Version of 3.1 is $0"
+
+  !insertmacro WindowsDesktopGetInstalledVersion 3.1 $0
+  DetailPrint "Installed Version of 3.1 is $0"
+
+  !insertmacro WindowsDesktopGetLatestVersion 5.0 $0
+  DetailPrint "Latest Version of 5.0 is $0"
+
+  !insertmacro WindowsDesktopGetInstalledVersion 5.0 $0
+  DetailPrint "Installed Version of 5.0 is $0"
+
+  !insertmacro WindowsDesktopGetLatestVersion 6.0 $0
+  DetailPrint "Latest Version of 6.0 is $0"
+
+  !insertmacro WindowsDesktopGetInstalledVersion 6.0 $0
+  DetailPrint "Installed Version of 6.0 is $0"
+
+  !insertmacro WindowsDesktopGetLatestVersion 7.0 $0
+  DetailPrint "Latest Version of 7.0 is $0"
+
+  !insertmacro WindowsDesktopGetInstalledVersion 7.0 $0
+  DetailPrint "Installed Version of 7.0 is $0"
+
+  !insertmacro WindowsDesktopGetLatestVersion 8.0 $0
+  DetailPrint "Latest Version of 8.0 is $0"
+
+  !insertmacro WindowsDesktopGetInstalledVersion 8.0 $0
+  DetailPrint "Installed Version of 8.0 is $0"
+
+  !insertmacro WindowsDesktopGetLatestVersion 9.0 $0
+  DetailPrint "Latest Version of 9.0 is $0"
+
+  !insertmacro WindowsDesktopGetInstalledVersion 9.0 $0
+  DetailPrint "Installed Version of 9.0 is $0"
+   
+  !insertmacro CheckWindowsDesktop 3.1
+  !insertmacro CheckWindowsDesktop 5.0
+  !insertmacro CheckWindowsDesktop 6.0
+  !insertmacro CheckWindowsDesktop 7.0
+  !insertmacro CheckWindowsDesktop 8.0
+  !insertmacro CheckWindowsDesktop 9.0
 
   WriteRegStr HKCU "Software\DotNetCore Test" "" $INSTDIR
   WriteUninstaller "$INSTDIR\Uninstall.exe"


### PR DESCRIPTION
This PR is an improved version of #6 and fully implements all dot net runtimes. It also adds the ability to override the target platform in case a x86 version shall be installed on a x64 Windows. The old macros are kept and mapped to the new generic functions. However, they are marked as deprecated because the naming is misleading (DotNetCore macro installs WindowsDesktop runtime).