### PR TITLE
Replace `azureedge.net` with `builds.dotnet.microsoft.com`

### DIFF
--- a/src/dotnetcore.nsh
+++ b/src/dotnetcore.nsh
@@ -87,7 +87,7 @@
 	Push ${Version}
 	Pop $R0 ; Version
 
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/latest.version
+	StrCpy $R1 https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/$R0/latest.version
 	DetailPrint "Querying latest version of dotnet $R0 from $R1"
 
 	; Fetch latest version of the desired dotnet version
@@ -197,12 +197,12 @@
 	${EndIf}
 
 	; todo can download as a .zip, which is smaller, then we'd need to unzip it before running it...
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
+	StrCpy $R1 https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
 
 	; For dotnet versions less than 5 the WindowsDesktop runtime has a different path
 	${WordFind} $R0 "." "+1" $R2
 	IntCmp $R2 5 +2 0 +2
-	StrCpy $R1 https://dotnetcli.azureedge.net/dotnet/Runtime/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
+	StrCpy $R1 https://builds.dotnet.microsoft.com/dotnet/Runtime/$R0/windowsdesktop-runtime-$R0-win-$R3.exe
 
 	DetailPrint "Downloading dotnet $R0 from $R1"
 


### PR DESCRIPTION
The `azureedge.net` domain is being retired and may no longer work in the future.

Fixes #9 